### PR TITLE
Use `rustversion` to activate the slice sorting functions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,11 +24,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
-    - uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-all-features
-    - name: Check all feature combinations
-      run: cargo check-all-features
+    - name: Check
+      run: cargo check
 
   clippy:
     runs-on: ubuntu-latest
@@ -48,11 +45,8 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.toolchain }}
-    - uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-all-features
-    - name: Test all feature combinations
-      run: cargo test-all-features
+    - name: Test
+      run: cargo test
       
   doc:
     runs-on: ubuntu-latest
@@ -75,10 +69,8 @@ jobs:
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-msrv
-    - name: Verify default msrv
+    - name: Verify MSRV
       run: cargo msrv verify
-    - name: Verify raised msrv
-      run: cargo msrv verify --rust-version 1.83.0 --features sort_slices
 
   coverage:
     runs-on: ubuntu-latest
@@ -117,15 +109,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-all-features
       - name: Set stable Rust as the default
         run: rustup default stable
       - name: Use minimal versions of dependencies
         run: cargo +nightly update -Zminimal-versions
-      - name: Test all feature combinations
-        run: cargo test-all-features --locked
+      - name: Test
+        run: cargo test
 
   no_std:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ This file contains all changes to the crate since version v0.1.0.
 
 ## 1.0.0 (unreleased)
 
-- Stabilized the API of the crate.
+### Breaking changes
+
+- Removed the `sort_slices` feature.
+ Those functions are now activated automatically on Rust versions 1.83.0 and later by using
+ the [`rustversion`](https://crates.io/crates/rustversion) crate.
 
 ## 0.2.9
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ version = "1.0.0"
 dependencies = [
  "quickcheck",
  "rand",
+ "rustversion",
 ]
 
 [[package]]
@@ -59,6 +60,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,9 @@ repository = "https://github.com/JSorngard/compile_time_sort"
 documentation = "https://docs.rs/compile_time_sort/"
 
 [dependencies]
+rustversion = "1.0.0"
 
 [features]
-# Enables the `sort_*_slice` functions and raises the MSRV of the crate from 1.59.0 to 1.83.0.
-sort_slices = []
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ documentation = "https://docs.rs/compile_time_sort/"
 [dependencies]
 rustversion = "1.0.0"
 
-[features]
-
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 quickcheck = { version = "1.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ const SORTED_ARRAY: [i32; 5] = into_sorted_i32_array(ARRAY);
 assert_eq!(SORTED_ARRAY, [-3, 0, 2, 3, i32::MAX]);
 ```
 
-Sort an array by reference:
+Sort by reference:
 
 ```rust
 use const_sort::sort_i32_slice;

--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ const SORTED_ARRAY: [i32; 5] = {
 assert_eq!(SORTED_ARRAY, [i32::MIN, -2, 0, 0, 5]);
 ```
 
-## Features
-
-`sort_slices`: enables the `sort_*_slice` functions and raises the MSRV of the crate from 1.59.0 to 1.83.0.
+The functions that sort slices by reference are only available on Rust version 1.83 and above.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ const SORTED_ARRAY: [i32; 5] = {
 assert_eq!(SORTED_ARRAY, [i32::MIN, -2, 0, 0, 5]);
 ```
 
-The functions that sort slices by reference are only available on Rust version 1.83 and above.
+The functions that sort slices by reference are only available on Rust versions 1.83 and above.
 
 <br>
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,20 +26,17 @@
 //! ```
 //!
 //! Sort an array by reference:
-#![cfg_attr(
-    feature = "sort_slices",
-    doc = r"```
-use compile_time_sort::sort_i32_slice;
-
-const SORTED_ARRAY: [i32; 5] = {
-    let mut arr = [5, i32::MIN, 0, -2, 0];
-    sort_i32_slice(&mut arr);
-    arr
-};
-
-assert_eq!(SORTED_ARRAY, [i32::MIN, -2, 0, 0, 5]);
-```"
-)]
+//! ```
+//! use compile_time_sort::sort_i32_slice;
+//!
+//! const SORTED_ARRAY: [i32; 5] = {
+//!     let mut arr = [5, i32::MIN, 0, -2, 0];
+//!     sort_i32_slice(&mut arr);
+//!     arr
+//! };
+//!
+//! assert_eq!(SORTED_ARRAY, [i32::MIN, -2, 0, 0, 5]);
+//! ```
 //!
 //! # Features
 //!
@@ -48,7 +45,7 @@ assert_eq!(SORTED_ARRAY, [i32::MIN, -2, 0, 0, 5]);
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 /// Defines a `const` function with the given name that takes in a mutable reference to a slice of the given type
 /// and sorts it using the quicksort algorithm.
 // This implementation is the one from <https://github.com/jonhoo/orst/blob/master/src/quicksort.rs> but made const.
@@ -144,7 +141,7 @@ macro_rules! const_array_quicksort {
 
 macro_rules! impl_const_quicksort {
     ($pub_name_array:ident, $pub_name_slice:ident, $qsort_slice_name:ident, $partition_slice_name:ident, $qsort_array_name:ident, $partition_array_name:ident, $tpe:ty) => {
-        #[cfg(feature = "sort_slices")]
+        #[rustversion::since(1.83.0)]
         const_slice_quicksort!{$qsort_slice_name, $tpe}
 
         const_array_quicksort!{$qsort_array_name, $partition_array_name, $tpe}
@@ -157,7 +154,7 @@ macro_rules! impl_const_quicksort {
             $qsort_array_name(array, 0, N)
         }
 
-        #[cfg(feature = "sort_slices")]
+        #[rustversion::since(1.83.0)]
         #[doc = concat!("Sorts the given slice of `", stringify!($tpe), "`s using the quicksort algorithm.")]
         pub const fn $pub_name_slice(slice: &mut [$tpe]) {
             $qsort_slice_name(slice);
@@ -265,7 +262,7 @@ impl_const_quicksort!(
     isize
 );
 
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 /// Sorts the given slice of `i8`s using the counting sort algorithm.
 pub const fn sort_i8_slice(slice: &mut [i8]) {
     if slice.is_empty() || slice.len() == 1 {
@@ -322,7 +319,7 @@ pub const fn into_sorted_i8_array<const N: usize>(mut array: [i8; N]) -> [i8; N]
     array
 }
 
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 /// Sorts the given slice of `u8`s using the counting sort algorithm.
 pub const fn sort_u8_slice(slice: &mut [u8]) {
     if slice.is_empty() || slice.len() == 1 {
@@ -377,7 +374,7 @@ pub const fn into_sorted_u8_array<const N: usize>(mut array: [u8; N]) -> [u8; N]
     array
 }
 
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 /// Sorts the given slice of `bool`s using the counting sort algorithm.
 pub const fn sort_bool_slice(slice: &mut [bool]) {
     if slice.is_empty() || slice.len() == 1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,8 @@
 //! assert_eq!(SORTED_ARRAY, [-3, 0, 2, 3, i32::MAX]);
 //! ```
 //!
-//! Sort an array by reference:
+//! Sort by reference:
+//!
 //! ```
 //! use compile_time_sort::sort_i32_slice;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,8 @@ macro_rules! impl_const_quicksort {
 
         #[rustversion::since(1.83.0)]
         #[doc = concat!("Sorts the given slice of `", stringify!($tpe), "`s using the quicksort algorithm.")]
+        #[doc = ""]
+        #[doc = "This function is only available on Rust versions 1.83 and above."]
         pub const fn $pub_name_slice(slice: &mut [$tpe]) {
             $qsort_slice_name(slice);
         }
@@ -264,6 +266,8 @@ impl_const_quicksort!(
 
 #[rustversion::since(1.83.0)]
 /// Sorts the given slice of `i8`s using the counting sort algorithm.
+///
+/// This function is only available on Rust versions 1.83 and above.
 pub const fn sort_i8_slice(slice: &mut [i8]) {
     if slice.is_empty() || slice.len() == 1 {
         return;
@@ -321,6 +325,8 @@ pub const fn into_sorted_i8_array<const N: usize>(mut array: [i8; N]) -> [i8; N]
 
 #[rustversion::since(1.83.0)]
 /// Sorts the given slice of `u8`s using the counting sort algorithm.
+///
+/// This function is only available on Rust versions 1.83 and above.
 pub const fn sort_u8_slice(slice: &mut [u8]) {
     if slice.is_empty() || slice.len() == 1 {
         return;
@@ -376,6 +382,8 @@ pub const fn into_sorted_u8_array<const N: usize>(mut array: [u8; N]) -> [u8; N]
 
 #[rustversion::since(1.83.0)]
 /// Sorts the given slice of `bool`s using the counting sort algorithm.
+///
+/// This function is only available on Rust versions 1.83 and above.
 pub const fn sort_bool_slice(slice: &mut [bool]) {
     if slice.is_empty() || slice.len() == 1 {
         return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,7 @@
 //! assert_eq!(SORTED_ARRAY, [i32::MIN, -2, 0, 0, 5]);
 //! ```
 //!
-//! # Features
-//!
-//! `sort_slices`: enables the `sort_*_slice` functions and raises the MSRV of the crate from 1.59.0 to 1.83.0.
+//! The functions that sort slices by reference are only available on Rust version 1.83 and above.
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! assert_eq!(SORTED_ARRAY, [i32::MIN, -2, 0, 0, 5]);
 //! ```
 //!
-//! The functions that sort slices by reference are only available on Rust version 1.83 and above.
+//! The functions that sort slices by reference are only available on Rust versions 1.83 and above.
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 use quickcheck::quickcheck;
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 
@@ -8,14 +8,14 @@ use compile_time_sort::{
     into_sorted_u16_array, into_sorted_u32_array, into_sorted_u64_array, into_sorted_u8_array,
 };
 
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 use compile_time_sort::{
     sort_bool_slice, sort_char_slice, sort_i128_slice, sort_i16_slice, sort_i32_slice,
     sort_i64_slice, sort_i8_slice, sort_isize_slice, sort_u128_slice, sort_u16_slice,
     sort_u32_slice, sort_u64_slice, sort_u8_slice, sort_usize_slice,
 };
 
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 macro_rules! quickcheck_slice_sort {
     ($tpe:ty, $quickcheck_fn:ident, $sort_fn:ident) => {
         quickcheck! {
@@ -68,25 +68,6 @@ macro_rules! test_unsigned_integer {
 
             let sorted_array = $array_sort_name(random_array);
             assert!(sorted_array.is_sorted());
-
-            #[cfg(feature = "sort_slices")]
-            {
-                const SORTED_SLICE: [$tpe; 3] = {
-                    let mut arr = REV_ARRAY;
-                    $slice_sort_name(&mut arr);
-                    arr
-                };
-
-                assert!(SORTED_SLICE.is_sorted());
-
-                let sorted_array = {
-                    let mut arr = random_array;
-                    $slice_sort_name(&mut arr);
-                    arr
-                };
-
-                assert!(sorted_array.is_sorted());
-            }
         }
     };
 }
@@ -99,18 +80,6 @@ macro_rules! test_signed_integer {
             const SORTED_ARRAY_WITH_NEGATIVES: [$tpe; 3] = $array_sort_name(ARRAY_WITH_NEGATIVES);
 
             assert!(SORTED_ARRAY_WITH_NEGATIVES.is_sorted());
-
-            #[cfg(feature = "sort_slices")]
-            {
-                const ARRAY_WITH_NEGATIVES: [$tpe; 3] = [0, -1, 2];
-                const SORTED_ARRAY_WITH_NEGATIVES: [$tpe; 3] = {
-                    let mut arr = ARRAY_WITH_NEGATIVES;
-                    $slice_sort_name(&mut arr);
-                    arr
-                };
-
-                assert!(SORTED_ARRAY_WITH_NEGATIVES.is_sorted());
-            }
         }
 
         // Also run all the tests for unsigned integers on the signed integers
@@ -141,33 +110,33 @@ test_signed_integer! {
     sort_i128_slice
 }
 
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {u8, quickcheck_u8_slice, sort_u8_slice}
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {u16, quickcheck_u16_slice, sort_u16_slice}
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {u32, quickcheck_u32_slice, sort_u32_slice}
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {u64, quickcheck_u64_slice, sort_u64_slice}
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {u128, quickcheck_u128_slice, sort_u128_slice}
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {usize, quickcheck_usize_slice, sort_usize_slice}
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {i8, quickcheck_i8_slice, sort_i8_slice}
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {i16, quickcheck_i16_slice, sort_i16_slice}
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {i32, quickcheck_i32_slice, sort_i32_slice}
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {i64, quickcheck_i64_slice, sort_i64_slice}
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {i128, quickcheck_i128_slice, sort_i128_slice}
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {isize, quickcheck_isize_slice, sort_isize_slice}
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {char, quickcheck_char_slice, sort_char_slice}
-#[cfg(feature = "sort_slices")]
+#[rustversion::since(1.83.0)]
 quickcheck_slice_sort! {bool, quickcheck_bool_slice, sort_bool_slice}
 
 #[test]
@@ -175,16 +144,7 @@ fn test_sort_bool() {
     const ARR: [bool; 4] = [false, true, false, true];
     const SORTED_ARR: [bool; 4] = into_sorted_bool_array(ARR);
 
-    #[cfg(feature = "sort_slices")]
-    const SORTED_SLICE: [bool; 4] = {
-        let mut arr = [true, false, true, false];
-        sort_bool_slice(&mut arr);
-        arr
-    };
-
     assert_eq!(SORTED_ARR, [false, false, true, true]);
-    #[cfg(feature = "sort_slices")]
-    assert_eq!(SORTED_SLICE, [false, false, true, true]);
 }
 
 #[test]


### PR DESCRIPTION
Instead of having a feature we can decorate the functions with `#[rustversion::since(1.83.0)]`.

https://crates.io/crates/rustversion